### PR TITLE
Add Pair types

### DIFF
--- a/README.md
+++ b/README.md
@@ -33,7 +33,7 @@ Getting Started
 Simply add the following lines to your build file:
 
 ```
-libraryDependencies += "au.com.cba.omnia" %% "grimlock-core" % "0.7.6"
+libraryDependencies += "au.com.cba.omnia" %% "grimlock-core" % "0.7.7"
 resolvers += "commbank-releases" at "http://commbank.artifactoryonline.com/commbank/ext-releases-local"
 ```
 

--- a/grimlock-core/src/main/scala/commbank/grimlock/framework/Pair.scala
+++ b/grimlock-core/src/main/scala/commbank/grimlock/framework/Pair.scala
@@ -1,0 +1,208 @@
+// Copyright 2019 Commonwealth Bank of Australia
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package commbank.grimlock.framework.pair
+
+import commbank.grimlock.framework.Cell
+import commbank.grimlock.framework.aggregate.{ Aggregator => Agg, Single }
+import commbank.grimlock.framework.content.Content
+import commbank.grimlock.framework.encoding.{ Codec, Value }
+import commbank.grimlock.framework.metadata.{ Schema, Type }
+import commbank.grimlock.framework.position.Position
+
+import java.util.Date
+
+import scala.reflect.{ classTag, ClassTag }
+import scala.reflect.runtime.universe.{ typeTag, TypeTag }
+import scala.util.matching.Regex
+
+import shapeless.{ HList, Nat }
+
+/** Codec for dealing with a pair of values. Each value must have a corresponding `Codec`. */
+case class PairCodec[
+  X : TypeTag,
+  Y : TypeTag
+](
+  xCodec: Codec[X],
+  yCodec: Codec[Y],
+  open: Char = '(',
+  separator: Char = ',',
+  close: Char = ')'
+ ) extends Codec[(X, Y)] { self =>
+  val converters: Set[Codec.Convert[(X, Y)]] = Set.empty
+  val date: Option[((X, Y)) => Date] = None
+  val integral: Option[Integral[(X, Y)]] = None
+  val numeric: Option[Numeric[(X, Y)]] = None
+  def ordering: Ordering[(X, Y)] = new Ordering[(X, Y)] {
+    def compare(x: (X, Y), y: (X, Y)): Int = self.compare(x, y)
+  }
+
+  def box(value: (X, Y)): Value[(X, Y)] = PairValue(value, this)
+
+  def compare(
+    x: (X, Y),
+    y: (X, Y)
+  ): Int = if (xCodec.compare(x._1, y._1) == 0) yCodec.compare(x._2, y._2) else xCodec.compare(x._1, y._1)
+
+  def decode(
+    str: String
+  ): Option[(X, Y)] = {
+    val pattern = s"\\${open}(.+)\\${separator}(.+)\\${close}".r
+    val (x, y) = str match {
+      case pattern(left, right) => (xCodec.decode(left), yCodec.decode(right))
+      case _ => (None, None)
+    }
+    for (a <- x; b <- y) yield (a, b)
+  }
+
+  def encode(value: (X, Y)): String = s"${open}${xCodec.encode(value._1)}${separator}${yCodec.encode(value._2)}${close}"
+
+  def toShortString = s"pair${separator.toString}${xCodec.toShortString}${separator.toString}${yCodec.toShortString}${separator.toString}${open.toString}${separator.toString}${close.toString}"
+}
+
+object PairCodec {
+  /** Pattern for parsing `PairCodec` from string with xCodec and yCodec provided. */
+  val Pattern: Regex = raw"pair(.)(.+)\1(.+)\1(.)\1(.)".r
+
+  /**
+   * Parse a PairCodec[X, Y] from a string.
+   *
+   * @param str String from which to parse the codec.
+   * @param xCodec Left Codec[X] to attempt to parse PairCodec.
+   * @param yCodec Left Codec[Y] to attempt to parse PairCodec.
+   *
+   * @return A `Some[PairCodec[X, Y]]` in case of success, `None` otherwise.
+   */
+  def fromShortString[X : TypeTag, Y : TypeTag](str: String, xCodec: Codec[X], yCodec: Codec[Y]): Option[PairCodec[X, Y]] = str match {
+    case Pattern(sep, x, y, open, close) if xCodec.toShortString == x && yCodec.toShortString == y =>
+      // sep, open, close are regex-ed to be single length strings. So we can safely take their first element
+      Option(PairCodec(xCodec, yCodec, open.head, sep.head, close.head))
+    case _ => None
+  }
+}
+
+case class PairValue[
+  X: TypeTag,
+  Y: TypeTag
+](
+  value: (X, Y),
+  codec: PairCodec[X, Y]
+) extends Value[(X, Y)] {
+  protected val ttag: TypeTag[(X, Y)] = typeTag[(X, Y)]
+
+  def cmp[V <% Value[_]](that: V): Option[Int] = that.as[(X, Y)].map(t => cmp(t))
+}
+
+/** Companion object to `PairValue` case class. */
+object PairValue {
+  /** `unapply` method for pattern matching. */
+  def unapply[X, Y](value: Value[_]): Option[(X, Y)] = classTag[(X, Y)].unapply(value.value)
+}
+
+case object PairType extends Type {
+  val name = "pair"
+
+  def toShortString: String = name.toString
+}
+
+case class PairSchema[X, Y]() extends Schema[(X, Y)] {
+  val classification = PairType
+
+  def validate(value: Value[(X, Y)]): Boolean = true
+}
+
+object PairSchema {
+  val Pattern = s"${PairType.name}.*".r
+   /**
+   * Parse a pair schema from string.
+   *
+   * @param str   The string to parse.
+   * @param codec The codec to parse with.
+   *
+   * @return A `Some[PairSchema]` if successful, `None` otherwise.
+   */
+  def fromShortString[X, Y](str: String, codec: PairCodec[X, Y]): Option[PairSchema[X, Y]] = str match {
+    case PatternName() => Option(PairSchema[X, Y]())
+    case _ => None
+  }
+
+  /** Pattern for matching short string nominal schema. */
+  private val PatternName = PairType.name.r
+}
+
+/* Aggregator to create PairValues
+*
+* Given two concatenated C#U[Cell[P]] values: `left` and `right`, with unique values within them but
+* have matching coordinates between them, it will produce a single C#U with all matching coordinates
+* filled to have `PairValue`s. This operation is conceptually similar to an inner join, with the
+* difference being that if duplicates are found all rows for that entry are discarded.
+*
+* Note: There is only support for turning `left` and `right` into the same type.
+*
+* @param left         String indicating the key for the left data
+* @param right        String indicating the key for the right data
+* @param codec        A Codec of type X for which the data should attempt to be cast.
+* @param dim          The dimension as a shapeless `Nat` for which the key string is to be found.
+* @param leftDefault  The default value, as an option for the left data.
+* @param rightDefault The default value, as an option for the right data.
+* */
+case class GeneratePair[
+  P <: HList,
+  S <: HList,
+  D <: Nat,
+  X : ClassTag : TypeTag
+](
+  left: String,
+  right: String,
+  codec: Codec[X],
+  dim: D,
+  leftDefault: Option[X] = None,
+  rightDefault: Option[X] = None
+)(implicit
+  ev1: Position.IndexConstraints.Aux[P, D, Value[String]]
+) extends Agg[P, S, S] {
+  type T = List[(String, X)]
+  type O[A] = Single[A]
+
+  val tTag = classTag[T]
+  val oTag = classTag[O[_]]
+
+  def prepare(cell: Cell[P]): Option[T] = cell.content.value.as[X].map(d => List((cell.position(dim).value, d)))
+
+  def reduce(lt: T, rt: T): T = lt ++ rt
+
+  def present(pos: Position[S], t: T): O[Cell[S]] = t match {
+    case List(first, second) =>
+      val l = if (first._1 == left) first._2 else second._2
+      val r = if (first._1 == right) first._2 else second._2
+      createSingle(pos, l, r)
+    case List((str, value)) if str == left =>
+      rightDefault.map(createSingle(pos, value, _)).getOrElse(Single())
+    case List((str, value)) if str == right =>
+      leftDefault.map(createSingle(pos, _, value)).getOrElse(Single())
+    case _ => Single()
+  }
+
+  private def createSingle(position: Position[S], left: X, right: X): O[Cell[S]] = {
+    Single(
+      Cell(
+        position,
+        Content(
+          PairSchema[X, X](),
+          PairValue((left, right), PairCodec(codec, codec))
+        )
+      )
+    )
+  }
+}

--- a/grimlock-core/src/main/scala/commbank/grimlock/framework/Slice.scala
+++ b/grimlock-core/src/main/scala/commbank/grimlock/framework/Slice.scala
@@ -54,7 +54,9 @@ case class Over[
 /** Companion object to `Over` case class. */
 object Over {
   /**
-   * Construct an `Over` for 1 dimension.
+   * Construct an `Over` for 1 dimension. Implicit parameter order is different from the case class constructor to
+   * avoid duplicate symbols compiler error. Without the re-ordering, the erasure of type parameters at run time makes
+   * the apply method indistinguishable from the case class constructor.
    *
    * @param dimension Dimension of the selected coordinate.
    */
@@ -66,8 +68,8 @@ object Over {
   ](
     dimension: D
   )(implicit
-    ev1: Position.IndexConstraints.Aux[P, D :: HNil, V :: HNil],
-    ev2: Position.RemoveConstraints.Aux[P, D :: HNil, R]
+    ev1: Position.RemoveConstraints.Aux[P, D, R],
+    ev2: Position.IndexConstraints.Aux[P, D, V]
   ): Over[P, D :: HNil, V :: HNil, R] = Over(dimension :: HNil)
 
   /**
@@ -140,7 +142,9 @@ case class Along[
 /** Companion object to `Along` case class. */
 object Along {
   /**
-   * Construct an `Along` for 1 dimension.
+   * Construct an `Along` for 1 dimension. Implicit parameter order is different from the case class constructor to
+   * avoid duplicate symbols compiler error. Without the re-ordering, the erasure of type parameters at run time makes
+   * the apply method indistinguishable from the case class constructor.
    *
    * @param dimension Dimension of the coordinate to exclude.
    */
@@ -152,8 +156,8 @@ object Along {
   ](
     dimension: D
   )(implicit
-    ev1: Position.IndexConstraints.Aux[P, D :: HNil, V :: HNil],
-    ev2: Position.RemoveConstraints.Aux[P, D :: HNil, S]
+    ev1: Position.RemoveConstraints.Aux[P, D, S],
+    ev2: Position.IndexConstraints.Aux[P, D, V]
   ): Along[P, D :: HNil, V :: HNil, S] = Along(dimension :: HNil)
 
   /**

--- a/grimlock-core/src/main/scala/commbank/grimlock/framework/Value.scala
+++ b/grimlock-core/src/main/scala/commbank/grimlock/framework/Value.scala
@@ -39,9 +39,19 @@ trait Value[T] {
   /** Return value as `X` (if an appropriate converter exists), or `None` if the conversion is not supported. */
   def as[X : ClassTag: TypeTag]: Option[X] = {
     val ct = implicitly[ClassTag[X]]
+    /** ClassTag's are unable to check parameters within classes. So for a set of ClassTags we wish to
+      * match on exact typeTags. For these sets all converters will result in None, because we test based
+      * on ttag: TypeTag[T]. */
+    val typeTagSet: Set[ClassTag[_]] = Set(classTag[Tuple1[_]], classTag[Tuple2[_, _]], classTag[List[_]])
 
     def cast(v: Any): Option[X] = v match {
-      case ct(x) if ttag == typeTag[X] => Option(x)
+      case ct(x) if typeTagSet.contains(ct) => castTypeTag(v)
+      case ct(x) => Option(x)
+      case _ => None
+    }
+
+    def castTypeTag(v: Any): Option[X] = v match {
+      case ct(x) if typeTag[X] == ttag => Option(x)
       case _ => None
     }
 

--- a/grimlock-core/src/main/scala/commbank/grimlock/framework/Value.scala
+++ b/grimlock-core/src/main/scala/commbank/grimlock/framework/Value.scala
@@ -21,10 +21,15 @@ import java.util.Date
 
 import scala.math.BigDecimal
 import scala.reflect.{ classTag, ClassTag }
+import scala.reflect.runtime.universe.{ typeTag, TypeTag }
 import scala.util.matching.Regex
 
 /** Trait for variable values. */
 trait Value[T] {
+
+  /** TypeTag of type of the Value. */
+  protected val ttag: TypeTag[T]
+
   /** The codec used to encode/decode this value. */
   val codec: Codec[T]
 
@@ -32,11 +37,11 @@ trait Value[T] {
   val value: T
 
   /** Return value as `X` (if an appropriate converter exists), or `None` if the conversion is not supported. */
-  def as[X : ClassTag]: Option[X] = {
+  def as[X : ClassTag: TypeTag]: Option[X] = {
     val ct = implicitly[ClassTag[X]]
 
     def cast(v: Any): Option[X] = v match {
-      case ct(x) => Option(x)
+      case ct(x) if ttag == typeTag[X] => Option(x)
       case _ => None
     }
 
@@ -185,6 +190,8 @@ object Value {
  */
 case class BinaryValue(value: Array[Byte], codec: Codec[Array[Byte]] = BinaryCodec) extends Value[Array[Byte]] {
   def cmp[V <% Value[_]](that: V): Option[Int] = that.as[Array[Byte]].map(ab => cmp(ab))
+
+  protected val ttag: TypeTag[Array[Byte]] = typeTag[Array[Byte]]
 }
 
 /** Companion object to `BinaryValue` case class. */
@@ -201,6 +208,8 @@ object BinaryValue {
  */
 case class BooleanValue(value: Boolean, codec: Codec[Boolean] = BooleanCodec) extends Value[Boolean] {
   def cmp[V <% Value[_]](that: V): Option[Int] = that.as[Boolean].map(b => cmp(b))
+
+  protected val ttag: TypeTag[Boolean] = typeTag[Boolean]
 }
 
 /** Companion object to `BooleanValue` case class. */
@@ -217,6 +226,8 @@ object BooleanValue {
  */
 case class DateValue(value: Date, codec: Codec[Date] = DateCodec()) extends Value[Date] {
   def cmp[V <% Value[_]](that: V): Option[Int] = that.as[Date].map(d => cmp(d))
+
+  protected val ttag: TypeTag[Date] = typeTag[Date]
 }
 
 /** Companion object to `DateValue` case class. */
@@ -236,6 +247,8 @@ object DateValue {
  */
 case class DecimalValue(value: BigDecimal, codec: Codec[BigDecimal]) extends Value[BigDecimal] {
   def cmp[V <% Value[_]](that: V): Option[Int] = that.as[BigDecimal].map(bd => cmp(bd))
+
+  protected val ttag: TypeTag[BigDecimal] = typeTag[BigDecimal]
 }
 
 /** Companion object to `DecimalValue` case class. */
@@ -252,6 +265,8 @@ object DecimalValue {
  */
 case class DoubleValue(value: Double, codec: Codec[Double] = DoubleCodec) extends Value[Double] {
   def cmp[V <% Value[_]](that: V): Option[Int] = that.as[Double].map(d => cmp(d))
+
+  protected val ttag: TypeTag[Double] = typeTag[Double]
 }
 
 /** Companion object to `DoubleValue` case class. */
@@ -268,6 +283,8 @@ object DoubleValue {
  */
 case class FloatValue(value: Float, codec: Codec[Float] = FloatCodec) extends Value[Float] {
   def cmp[V <% Value[_]](that: V): Option[Int] = that.as[Float].map(d => cmp(d))
+
+  protected val ttag: TypeTag[Float] = typeTag[Float]
 }
 
 /** Companion object to `FloatValue` case class. */
@@ -288,6 +305,8 @@ case class IntValue(value: Int, codec: Codec[Int] = IntCodec) extends Value[Int]
     .map(i => super.cmp(i))
     .orElse(that.as[Long].map(l => super.cmp(l.toInt)))
     .orElse(that.as[Double].map(d => super.cmp(if (d > value) math.ceil(d).toInt else math.floor(d).toInt)))
+
+  protected val ttag: TypeTag[Int] = typeTag[Int]
 }
 
 /** Companion object to `IntValue` case class. */
@@ -307,6 +326,8 @@ case class LongValue(value: Long, codec: Codec[Long] = LongCodec) extends Value[
     .as[Long]
     .map(l => super.cmp(l))
     .orElse(that.as[Double].map(d => super.cmp(if (d > value) math.ceil(d).toLong else math.floor(d).toLong)))
+
+  protected val ttag: TypeTag[Long] = typeTag[Long]
 }
 
 /** Companion object to `LongValue` case class. */
@@ -323,6 +344,8 @@ object LongValue {
  */
 case class StringValue(value: String, codec: Codec[String] = StringCodec) extends Value[String] {
   def cmp[V <% Value[_]](that: V): Option[Int] = that.as[String].map(s => cmp(s))
+
+  protected val ttag: TypeTag[String] = typeTag[String]
 }
 
 /** Companion object to `StringValue` case class. */
@@ -339,6 +362,8 @@ object StringValue {
  */
 case class TimestampValue(value: Timestamp, codec: Codec[Timestamp] = TimestampCodec) extends Value[Timestamp] {
   def cmp[V <% Value[_]](that: V): Option[Int] = that.as[Timestamp].map(t => cmp(t))
+
+  protected val ttag: TypeTag[Timestamp] = typeTag[Timestamp]
 }
 
 /** Companion object to `TimestampValue` case class. */
@@ -355,6 +380,8 @@ object TimestampValue {
  */
 case class TypeValue(value: Type, codec: Codec[Type] = TypeCodec) extends Value[Type] {
   def cmp[V <% Value[_]](that: V): Option[Int] = that.as[Type].map(t => cmp(t))
+
+  protected val ttag: TypeTag[Type] = typeTag[Type]
 }
 
 /** Companion object to `TypeValue` case class. */

--- a/grimlock-core/src/test/scala/commbank/grimlock/Pair.scala
+++ b/grimlock-core/src/test/scala/commbank/grimlock/Pair.scala
@@ -1,0 +1,376 @@
+// Copyright 2019 Commonwealth Bank of Australia
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package commbank.grimlock.test
+
+import commbank.grimlock.framework.Cell
+import commbank.grimlock.framework.content.Content
+import commbank.grimlock.framework.encoding.{
+  DateCodec,
+  DecimalCodec,
+  DoubleCodec,
+  DoubleValue,
+  IntCodec,
+  StringCodec,
+  StringValue,
+  TimestampCodec
+}
+import commbank.grimlock.framework.metadata.Type
+import commbank.grimlock.framework.pair.{ GeneratePair, PairCodec, PairSchema, PairValue }
+import commbank.grimlock.framework.position.Position
+
+import java.sql.Timestamp
+import java.util.Date
+
+import scala.math.BigDecimal
+import scala.reflect.runtime.universe.TypeTag
+
+import shapeless.nat._0
+
+class TestPairCodec extends TestGrimlock {
+  val pair1 = (1.0, "abcde")
+  val pair2 = ("foo", 7)
+  val pair3 = ("baz", 15)
+  val pair4 = ("baz", 2)
+
+  "A PairCodec" should "have a name" in {
+    PairCodec(DoubleCodec, StringCodec).toShortString shouldBe "pair,double,string,(,)"
+  }
+
+  it should "decode a correct value" in {
+    PairCodec(DoubleCodec, StringCodec, ')', '#', '(').decode(")1.0#abcde(") shouldBe Option(pair1)
+  }
+
+  it should "encode a correct value" in {
+    PairCodec(StringCodec, IntCodec, '{', '_', '}').encode(pair2) shouldBe "{foo_7}"
+  }
+
+  it should "compare a correct value" in {
+    PairCodec(StringCodec, IntCodec).compare(pair2, pair3) > 0 shouldBe true
+    PairCodec(StringCodec, IntCodec).compare(pair4, pair3) < 0 shouldBe true
+    PairCodec(StringCodec, IntCodec).compare(pair4, pair4) shouldBe 0
+  }
+
+  it should "box correctly" in {
+    PairCodec(DoubleCodec, StringCodec, '*', '*', '*').box(pair1) shouldBe
+      PairValue(pair1, PairCodec(DoubleCodec, StringCodec, '*', '*', '*'))
+  }
+
+  it should "return fields" in {
+    PairCodec(IntCodec, IntCodec).converters.size shouldBe 0
+
+    PairCodec(StringCodec, DoubleCodec).date.isEmpty shouldBe true
+    PairCodec(StringCodec, DoubleCodec).integral.isEmpty shouldBe true
+    PairCodec(StringCodec, DoubleCodec).numeric.isEmpty shouldBe true
+  }
+}
+
+class TestPairValue extends TestGrimlock {
+  import commbank.grimlock.framework.environment.implicits.{ booleanToValue, doubleToValue, intToValue }
+
+  val cdcFoo = PairCodec(DoubleCodec, StringCodec, '{', '*', '}')
+  val cdcBar = PairCodec(StringCodec, DoubleCodec)
+  val foo = (1.0, "abc")
+  val fooBig = (2.0, "abc")
+  val fooBig2 = (1.0, "def")
+  val bar = ("def", 1.001)
+  val dvfoo = PairValue(foo, cdcFoo)
+  val dvfooBig = PairValue(fooBig, cdcFoo)
+  val dvfooBig2 = PairValue(fooBig2, cdcFoo)
+  val dvbar = PairValue(bar, cdcBar)
+
+  "A PairValue" should "return its short string" in {
+    dvfoo.toShortString shouldBe "{1.0*abc}"
+  }
+
+  it should "not return a date" in {
+    dvfoo.as[Date] shouldBe None
+  }
+
+  it should "not return a string" in {
+    dvfoo.as[String] shouldBe None
+    dvfoo.as[String] shouldBe None
+  }
+
+  it should "not return a double" in {
+    dvfoo.as[Double] shouldBe None
+  }
+
+  it should "not return a float" in {
+    dvfoo.as[Float] shouldBe None
+  }
+
+  it should "not return a long" in {
+    dvfoo.as[Long] shouldBe None
+  }
+
+  it should "not return a int" in {
+    dvfoo.as[Int] shouldBe None
+  }
+
+  it should "not return a boolean" in {
+    dvfoo.as[Boolean] shouldBe None
+  }
+
+  it should "not return a type" in {
+    dvfoo.as[Type] shouldBe None
+  }
+
+  it should "not return a timestamp" in {
+    dvfoo.as[Timestamp] shouldBe None
+  }
+
+  it should "not return a byte array" in {
+    dvfoo.as[Array[Byte]] shouldBe None
+  }
+
+  it should "not return a decimal" in {
+    dvfoo.as[BigDecimal] shouldBe None
+  }
+
+  it should "return a pair when given correct types" in {
+    dvfoo.as[(Double, String)] shouldBe Option((1.0, "abc"))
+    dvbar.as[(String, Double)] shouldBe Option(("def", 1.001))
+  }
+
+  it should "not return a pair when given incorrect types" in {
+    dvfoo.as[(Timestamp, Date)] shouldBe None
+    dvbar.as[(BigDecimal, Boolean)] shouldBe None
+  }
+
+  it should "equal itself" in {
+    dvfoo.equ(dvfoo) shouldBe true
+    dvfoo.equ(PairValue(foo, cdcFoo)) shouldBe true
+  }
+
+  it should "not equal another pair" in {
+    StringValue("foo").equ(DoubleValue(1.0))
+    dvfoo.equ(dvbar) shouldBe false
+    dvfoo.equ(dvfooBig) shouldBe false
+  }
+
+  it should "not equal another value" in {
+    dvfoo.equ(2) shouldBe false
+    dvfoo.equ(2.0) shouldBe false
+    dvfoo.equ(false) shouldBe false
+  }
+
+  it should "match a matching pattern" in {
+    dvfoo.like("^\\{...\\*...\\}".r) shouldBe true
+  }
+
+  it should "not match a non-existing pattern" in {
+    dvfoo.like("^_".r) shouldBe false
+  }
+
+  it should "identify a smaller value calling lss" in {
+    dvfoo.lss(dvfooBig) shouldBe true
+    dvfoo.lss(dvfooBig2) shouldBe true
+  }
+
+  it should "not identify an equal value calling lss" in {
+    dvbar.lss(dvbar) shouldBe false
+  }
+
+  it should "not identify a greater value calling lss" in {
+    dvfooBig.lss(dvfoo) shouldBe false
+  }
+
+  it should "not identify another value calling lss" in {
+    dvfooBig.lss(dvfoo) shouldBe false
+    dvfooBig2.lss(dvfoo) shouldBe false
+  }
+
+  it should "identify a smaller value calling leq" in {
+    dvfoo.leq(dvfooBig) shouldBe true
+    dvfoo.leq(dvfooBig2) shouldBe true
+  }
+
+  it should "identify an equal value calling leq" in {
+    dvbar.leq(dvbar) shouldBe true
+  }
+
+  it should "not identify a greater value calling leq" in {
+    dvfooBig.leq(dvfoo) shouldBe false
+    dvfooBig2.leq(dvfoo) shouldBe false
+  }
+
+  it should "not identify another value calling leq" in {
+    dvbar.leq(2) shouldBe false
+  }
+
+  it should "not identify a smaller value calling gtr" in {
+    dvfoo.gtr(dvfooBig) shouldBe false
+    dvfoo.gtr(dvfooBig2) shouldBe false
+  }
+
+  it should "not identify an equal value calling gtr" in {
+    dvbar.gtr(dvbar) shouldBe false
+  }
+
+  it should "identify a greater value calling gtr" in {
+    dvfooBig.gtr(dvfoo) shouldBe true
+    dvfooBig2.gtr(dvfoo) shouldBe true
+  }
+
+  it should "not identify another value calling gtr" in {
+    dvbar.gtr(2) shouldBe false
+  }
+
+  it should "not identify a smaller value calling geq" in {
+    dvfoo.geq(dvfooBig) shouldBe false
+    dvfoo.geq(dvfooBig2) shouldBe false
+  }
+
+  it should "identify an equal value calling geq" in {
+    dvbar.geq(dvbar) shouldBe true
+  }
+
+  it should "identify a greater value calling geq" in {
+    dvfooBig.geq(dvfoo) shouldBe true
+    dvfooBig2.geq(dvfoo) shouldBe true
+  }
+
+  it should "not identify another value calling geq" in {
+    dvbar.geq(2) shouldBe false
+  }
+}
+
+class TestPairSchema extends TestGrimlock {
+  val dfmt = new java.text.SimpleDateFormat("dd/MM/yyyy")
+  val date2001 = dfmt.parse("01/01/2001")
+  val one = BigDecimal(1.0)
+
+  "A PairSchema" should "return its string representation" in {
+    PairSchema[String, Double]().toShortString(PairCodec(StringCodec, DoubleCodec)) shouldBe "pair"
+    PairSchema[Date, Timestamp]().toShortString(PairCodec(DateCodec(), TimestampCodec)) shouldBe "pair"
+  }
+
+  it should "validate a correct value" in {
+    PairSchema[String, Double]().validate(PairValue(("abc", 1.0), PairCodec(StringCodec, DoubleCodec))) shouldBe true
+    PairSchema[Timestamp, BigDecimal]()
+      .validate(PairValue((new Timestamp(date2001.getTime), one), PairCodec(TimestampCodec, DecimalCodec(5, 4)))) shouldBe true
+  }
+
+  it should "not validate an incorrect value" in {
+    // TODO: it allows all values of type (X, Y). So this test is redundant
+  }
+
+  it should "parse correctly" in {
+    PairSchema.fromShortString("pair", PairCodec(IntCodec, StringCodec)) shouldBe Option(PairSchema[Int, String])
+  }
+
+  it should "not parse an incorrect string" in {
+    PairSchema.fromShortString("Xair", PairCodec(StringCodec, IntCodec)) shouldBe None
+  }
+}
+
+class TestGeneratePair extends TestAggregators {
+  import commbank.grimlock.framework.environment.implicits.stringToValue
+
+  def getPairContent[
+    X : TypeTag,
+    Y : TypeTag
+  ](
+    left: X,
+    right: Y,
+    codec: PairCodec[X, Y],
+    schema: PairSchema[X ,Y] = PairSchema[X, Y]()
+  ): Content =
+    Content(schema, PairValue((left, right), codec))
+
+  val cellD1 = Cell(Position("left", "foo"), getDoubleContent(1))
+  val cellD2 = Cell(Position("right", "foo"), getDoubleContent(2))
+  val tD1 = List(("left", 1))
+  val tD2 = List(("right", 2))
+
+  val cellS1 = Cell(Position("left", "bar"), getStringContent("foo"))
+  val cellS2 = Cell(Position("right", "bar"), getStringContent("baz"))
+  val tS1 = List(("left", "foo"))
+  val tS2 = List(("right", "baz"))
+
+  val stringDefault = "string.default"
+  val doubleDefault: Double = -999.0
+
+  "A GeneratePair" should "prepare, reduce and present Doubles" in {
+    val obj = GeneratePair[P, S, _0, Double]("left", "right", DoubleCodec, _0)
+
+    val t1 = obj.prepare(cellD1)
+    t1 shouldBe Option(tD1)
+
+    val t2 = obj.prepare(cellD2)
+    t2 shouldBe Option(tD2)
+
+    val r = obj.reduce(t1.get, t2.get)
+    r shouldBe (tD1 ++ tD2)
+
+    val c = obj.present(Position("foo"), r).result
+    c shouldBe Option(Cell(Position("foo"), getPairContent(1.0, 2.0, PairCodec(DoubleCodec, DoubleCodec))))
+  }
+
+  it should "prepare, reduce and present Strings" in {
+    val obj = GeneratePair[P, S, _0, String]("left", "right", StringCodec, _0)
+
+    val t1 = obj.prepare(cellS1)
+    t1 shouldBe Option(tS1)
+
+    val t2 = obj.prepare(cellS2)
+    t2 shouldBe Option(tS2)
+
+    val r = obj.reduce(t1.get, t2.get)
+    r shouldBe (tS1 ++ tS2)
+
+    val c = obj.present(Position("foo"), r).result
+    c shouldBe Option(Cell(Position("foo"), getPairContent("foo", "baz", PairCodec(StringCodec, StringCodec))))
+  }
+
+  it should "prepare, reduce and present expanded" in {
+    val obj = GeneratePair[P, S, _0, Double]("left", "right", DoubleCodec, _0)
+      .andThenRelocate(_.position.append("pair").toOption)
+
+    val t1 = obj.prepare(cellD1)
+    val t2 = obj.prepare(cellD2)
+    val r = obj.reduce(t1.get, t2.get)
+    val c = obj.present(Position("foo"), r).result
+    c shouldBe Option(Cell(Position("foo", "pair"), getPairContent(1.0, 2.0, PairCodec(DoubleCodec, DoubleCodec))))
+  }
+
+  it should "present with default values for left" in {
+    val obj = GeneratePair[P, S, _0, String]("left", "right", StringCodec, _0, Option(stringDefault), None)
+    val t = obj.prepare(cellS2)
+    val c = obj.present(Position("foo"), t.get).result
+    c shouldBe Option(Cell(Position("foo"), getPairContent(stringDefault, "baz", PairCodec(StringCodec, StringCodec))))
+  }
+
+  it should "present with default values for right" in {
+    val obj = GeneratePair[P, S, _0, Double]("left", "right", DoubleCodec, _0, None, Option(doubleDefault))
+    val t = obj.prepare(cellD1)
+    val c = obj.present(Position("foo"), t.get).result
+    c shouldBe Option(Cell(Position("foo"), getPairContent(1.0, doubleDefault, PairCodec(DoubleCodec, DoubleCodec))))
+  }
+
+  it should "present empty with no default values" in {
+    val obj = GeneratePair[P, S, _0, Double]("left", "right", DoubleCodec, _0)
+    val t = List.empty[(String, Double)]
+    val c = obj.present(Position("foo"), t).result
+      c shouldBe None
+  }
+
+  it should "present empty with both default values and no input" in {
+    val obj = GeneratePair[P, S, _0, Double]("left", "right", DoubleCodec, _0, Option(doubleDefault), Option(doubleDefault))
+    val t = List.empty[(String, Double)]
+    val c = obj.present(Position("foo"), t).result
+      c shouldBe None
+  }
+}

--- a/grimlock-examples/src/main/scala/commbank/grimlock/scala/Event.scala
+++ b/grimlock-examples/src/main/scala/commbank/grimlock/scala/Event.scala
@@ -32,6 +32,7 @@ import commbank.grimlock.scala.environment.implicits._
 
 import scala.collection.immutable.StringOps
 import scala.io.Source
+import scala.reflect.runtime.universe.{ typeTag, TypeTag }
 
 import shapeless.{ HList, Nat }
 import shapeless.nat.{ _0, _1 }
@@ -71,6 +72,7 @@ case object ExampleEventSchema extends Schema[ExampleEvent] {
 
 // Define a value that wraps the event.
 case class ExampleEventValue(value: ExampleEvent) extends Value[ExampleEvent] {
+  val ttag: TypeTag[ExampleEvent] = typeTag[ExampleEvent]
   val codec = ExampleEventCodec
 
   def cmp[V <% Value[_]](that: V): Option[Int] = that.as[ExampleEvent].map(e => cmp(e))

--- a/grimlock-examples/src/main/scala/commbank/grimlock/scalding/Event.scala
+++ b/grimlock-examples/src/main/scala/commbank/grimlock/scalding/Event.scala
@@ -35,6 +35,7 @@ import com.twitter.scalding.TDsl.sourceToTypedPipe
 import com.twitter.scalding.typed.TypedPipe
 
 import scala.collection.immutable.StringOps
+import scala.reflect.runtime.universe.{ typeTag, TypeTag }
 
 import shapeless.{ HList, Nat }
 import shapeless.nat.{ _0, _1 }
@@ -72,6 +73,7 @@ case object ExampleEventSchema extends Schema[ExampleEvent] {
 
 // Define a value that wraps the event.
 case class ExampleEventValue(value: ExampleEvent) extends Value[ExampleEvent] {
+  val ttag: TypeTag[ExampleEvent] = typeTag[ExampleEvent]
   val codec = ExampleEventCodec
 
   def cmp[V <% Value[_]](that: V): Option[Int] = that.as[ExampleEvent].map(e => cmp(e))

--- a/grimlock-examples/src/main/scala/commbank/grimlock/spark/Event.scala
+++ b/grimlock-examples/src/main/scala/commbank/grimlock/spark/Event.scala
@@ -34,6 +34,7 @@ import org.apache.spark.rdd.RDD
 import org.apache.spark.sql.SparkSession
 
 import scala.collection.immutable.StringOps
+import scala.reflect.runtime.universe.{ typeTag, TypeTag }
 
 import shapeless.{ HList, Nat }
 import shapeless.nat.{ _0, _1 }
@@ -74,6 +75,7 @@ case object ExampleEventSchema extends Schema[ExampleEvent] {
 
 // Define a value that wraps the event.
 case class ExampleEventValue(value: ExampleEvent) extends Value[ExampleEvent] {
+  val ttag: TypeTag[ExampleEvent] = typeTag[ExampleEvent]
   val codec = ExampleEventCodec
 
   def cmp[V <% Value[_]](that: V): Option[Int] = that.as[ExampleEvent].map(e => cmp(e))

--- a/version.sbt
+++ b/version.sbt
@@ -12,4 +12,4 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-version in ThisBuild := "0.7.6"
+version in ThisBuild := "0.7.7"


### PR DESCRIPTION
- add classes `PairValue`, `PairCodec`, `PairSchema`
- add an aggregator, `GeneratePair`, to construct a matrix of `PairValue`s from two concatenated matrices.